### PR TITLE
Bump up to Alpine 3.9 and use AdoptOpenJDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,13 @@ RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | \
 RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | \
     JABBA_COMMAND="install adopt@1.10.0-2 -o /usr/lib/jvm/jdk10" bash
 
-RUN curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | \
-    JABBA_COMMAND="install adopt@1.11.0-2 -o /usr/lib/jvm/jdk11" bash
-
+RUN JDK11_URL="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk11u-2019-02-20-11-53/OpenJDK11U-jdk_x64_linux_hotspot_2019-02-20-11-53.tar.gz" \
+    && JDK11_SHA256=35465cc7319ad4d790c540628033c14b10fa98f2006eb4dcaf886f169e5dd8e7 \
+    && curl -Ls ${JDK11_URL} -o /tmp/jdk11.tar.gz \
+    && echo "${JDK11_SHA256}  /tmp/jdk11.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/lib/jvm/jdk11 \
+    && tar -xf /tmp/jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1 \
+    && rm /tmp/jdk11.tar.gz
 
 WORKDIR /
 


### PR DESCRIPTION
During Zinc PR, I noticed that JDK 11 is segfaulting at some point, but things run ok on my local environment.
This bumps the base image to Alpine 3.9, and also changes the JVM to AdoptOpenJDK distribution of JDK 8, 10, and 11.
